### PR TITLE
if (process.stdin.isTTY)

### DIFF
--- a/lib/gistup/get-settings.js
+++ b/lib/gistup/get-settings.js
@@ -34,7 +34,9 @@ module.exports = function(callback) {
       console.log("");
       process.stdout.write("Press any key to open GitHub… ");
 
-      process.stdin.setRawMode(true);
+      if (process.stdin.isTTY){
+        process.stdin.setRawMode(true);
+      }
       process.stdin.resume();
       process.stdin.once("data", function() {
         child.exec(open + " 'https://github.com/settings/tokens/new'", function(error) {


### PR DESCRIPTION
idea from
https://github.com/nodejs/node-v0.x-archive/issues/8204#issuecomment-52720760

Without this if statement  received error on windows system

    c:\npm\node_modules\gistup\lib\gistup\get-settings.js:37
    process.stdin.setRawMode(true);
    ^
    
    TypeError: process.stdin.setRawMode is not a function
    at ReadFileContext.callback
    (c:\npm\node_modules\gistup\lib\gistup\get-settings.js:37:21)
    at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:303:13)