### PR TITLE
Changes default branch to main

### DIFF
--- a/bin/gistup
+++ b/bin/gistup
@@ -176,7 +176,7 @@ function createGist(token, callback) {
 }
 
 function gitRemoteAdd(id, callback) {
-  child.exec("git remote add --track master " + quote.single(argv.remote) + " git@gist.github.com:" + id + ".git", function(error, stdout, stderr) {
+  child.exec("git remote add --track main " + quote.single(argv.remote) + " git@gist.github.com:" + id + ".git", function(error, stdout, stderr) {
     if (!error && stderr) process.stderr.write(stderr), error = new Error("git remote failed.");
     if (!error && stdout) process.stdout.write(stdout);
     callback(error);
@@ -184,7 +184,7 @@ function gitRemoteAdd(id, callback) {
 }
 
 function gitPush(callback) {
-  child.exec("git push -fu " + quote.single(argv.remote) + " master", function(error, stdout, stderr) {
+  child.exec("git push -fu " + quote.single(argv.remote) + " main", function(error, stdout, stderr) {
     if (!error && stderr) process.stderr.write(stderr); // ignore warnings
     if (!error && stdout) process.stdout.write(stdout);
     callback(error);


### PR DESCRIPTION
Github has [switched](https://github.com/github/renaming#new-repositories-use-main-as-default-branch-name) to using `main` as the default branch. `gistup` throws an error when it tries to push to `master`: 

```
[main (root-commit) 37d4802] Initial gistup commit.
 5 files changed, 217 insertions(+)
 create mode 100644 README.md
 create mode 100644 d3_.js
 create mode 100644 index.html
 create mode 100644 script.js
 create mode 100644 style.css
gist 36cca45fe60b3d5533ceaeb4a6bec0c8 created!
https://gist.github.com/36cca45fe60b3d5533ceaeb4a6bec0c8
/usr/local/lib/node_modules/gistup/lib/gistup/unless.js:11
    throw error;
    ^

Error: Command failed: git push -fu 'origin' master
error: src refspec master does not match any
error: failed to push some refs to 'gist.github.com:36cca45fe60b3d5533ceaeb4a6bec0c8.git'

    at ChildProcess.exithandler (child_process.js:303:12)
    at ChildProcess.emit (events.js:311:20)
    at maybeClose (internal/child_process.js:1021:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5) {
  killed: false,
  code: 1,
  signal: null,
  cmd: "git push -fu 'origin' master"
}
```